### PR TITLE
Add browser demo, shims for extension APIs, and dependency upgrades

### DIFF
--- a/es6/app.js
+++ b/es6/app.js
@@ -4,7 +4,6 @@ import widgets from './widgets/widgets';
 import pages from './pages/pages';
 import './../scss/reset.scss';
 import './../scss/main.scss';
-import '../node_modules/spectrum-colorpicker/spectrum.css';
 
 let app = {
     data: {},

--- a/es6/pages/pages.js
+++ b/es6/pages/pages.js
@@ -92,13 +92,16 @@ export default {
         if (page === 'themes') {
             if (!this.modules.find((m) => m.name === 'themes')) {
                 try {
-                    const mod = await import('../widgets/themes');
-                    const themes = mod.default || mod;
-                    themes.init(document);
-                    this.modules.push(themes);
-                } catch (e) {
-                    util.error('Failed to load themes module: ' + e);
-                }
+            // Load the page module for themes lazily (this will manage its own
+            // lazy-loading of the themes widget).
+            const mod = await import('./themes');
+            const themesPage = mod.default || mod;
+            // Initialize the page module so its DOM hooks are wired.
+            if (themesPage.init) themesPage.init(document);
+            this.modules.push(themesPage);
+        } catch (e) {
+            util.error('Failed to load themes page module: ' + e);
+        }
             }
         }
 

--- a/es6/pages/pages.js
+++ b/es6/pages/pages.js
@@ -5,7 +5,6 @@ import todos from './todos';
 import sessions from './sessions';
 import apps from './apps';
 import bookmarks from './bookmarks';
-import themes from './themes';
 import ext from '../utils/extension';
 import 'metro-select';
 export default {
@@ -15,7 +14,7 @@ export default {
         chooser: document.getElementById('pages-chooser'),
     },
 
-    modules: [todos, sessions, apps, bookmarks, themes],
+    modules: [todos, sessions, apps, bookmarks],
 
     init: function(document) {
         this.showOptions = false;
@@ -85,9 +84,23 @@ export default {
      *
      * @param {any} page The new page.
      */
-    changePage: function changePage(page) {
+    changePage: async function changePage(page) {
         this.page = page;
         storage.save('page', page);
+
+        // If themes was requested, lazy-load it and add to modules.
+        if (page === 'themes') {
+            if (!this.modules.find((m) => m.name === 'themes')) {
+                try {
+                    const mod = await import('../widgets/themes');
+                    const themes = mod.default || mod;
+                    themes.init(document);
+                    this.modules.push(themes);
+                } catch (e) {
+                    util.error('Failed to load themes module: ' + e);
+                }
+            }
+        }
 
         let moduleIndex = this.modules
             .map((m) => {

--- a/es6/pages/themes.js
+++ b/es6/pages/themes.js
@@ -1,6 +1,5 @@
 import jquery from 'jquery';
 import PagebaseGrouped from '../pagebase/pagebase_grouped';
-import themesWidget from '../widgets/themes';
 import modal from '../utils/modal';
 import util from '../utils/util';
 import storage from '../utils/storage';
@@ -40,7 +39,7 @@ export default {
         infoFragment: util.createElement('<span class="info"></span>'),
     },
 
-    init: function() {
+    init: async function() {
         this.elems.rootNode = document.getElementById(
             'internal-selector-themes'
         );
@@ -52,11 +51,23 @@ export default {
             this.templateFunc.bind(this)
         );
 
-        this.themesWidget.themeAdded = this.themeAdded.bind(this);
-        this.themesWidget.themeRemoved = this.themeRemoved.bind(this);
+        // Lazy-load the themes widget so the heavy theme/editor code is only
+        // loaded when the themes page is initialized.
+        try {
+            const mod = await import('../widgets/themes');
+            this.themesWidget = mod.default || mod;
+            if (this.themesWidget) {
+                this.themesWidget.themeAdded = this.themeAdded.bind(this);
+                this.themesWidget.themeRemoved = this.themeRemoved.bind(this);
+            }
+        } catch (e) {
+            util.error('Could not load themes widget: ' + e);
+            this.themesWidget = null;
+        }
 
         this.loadThemes();
     },
+
 
     /**
      * Called when the sort order has been changed.
@@ -125,8 +136,12 @@ export default {
         let titleWrap = this.templates.titleWrapFragment.cloneNode(true);
         titleWrap.firstElementChild.appendChild(title);
 
-        if (this.themesWidget.data.title === theme.title) {
-            util.addClass(titleWrap.firstElementChild, 'active');
+        try {
+            if (this.themesWidget && this.themesWidget.data && this.themesWidget.data.title === theme.title) {
+                util.addClass(titleWrap.firstElementChild, 'active');
+            }
+        } catch (e) {
+            // ignore if themesWidget isn't available yet
         }
 
         fragment.appendChild(titleWrap);

--- a/es6/utils/script.js
+++ b/es6/utils/script.js
@@ -1,9 +1,25 @@
 import jquery from 'jquery';
-import tinycolor from 'tinycolor2';
 import jss from 'jss';
-import trianglify from 'trianglify';
 import util from './util';
 import defaults from './defaults';
+
+// Lazy-load heavy color/graphics libraries when needed to reduce initial bundle size
+let _tinycolor = null;
+let _trianglify = null;
+const getTinycolor = async () => {
+    if (!_tinycolor) {
+        const mod = await import('tinycolor2');
+        _tinycolor = mod.default || mod;
+    }
+    return _tinycolor;
+};
+const getTrianglify = async () => {
+    if (!_trianglify) {
+        const mod = await import('trianglify');
+        _trianglify = mod.default || mod;
+    }
+    return _trianglify;
+};
 
 export default {
     init: function() {},
@@ -43,17 +59,20 @@ export default {
                 'split complements',
             ]);
 
-            theme.themeContent.mainColor = tinycolor.random().toHexString();
-            theme.themeContent.baseColor = tinycolor.random().toHexString();
-            theme.themeContent.titleColor = tinycolor
-                .random()
-                .toHexString();
-            theme.themeContent.optionsColor = tinycolor
-                .random()
-                .toHexString();
-            theme.themeContent.backgroundColor = tinycolor
-                .random()
-                .toHexString();
+            // Use lazy tinycolor
+            getTinycolor().then((tinycolor) => {
+                theme.themeContent.mainColor = tinycolor.random().toHexString();
+                theme.themeContent.baseColor = tinycolor.random().toHexString();
+                theme.themeContent.titleColor = tinycolor
+                    .random()
+                    .toHexString();
+                theme.themeContent.optionsColor = tinycolor
+                    .random()
+                    .toHexString();
+                theme.themeContent.backgroundColor = tinycolor
+                    .random()
+                    .toHexString();
+            }).catch((e) => { util.error('Could not load tinycolor: ' + e); });
 
             theme.themeContent['font-chooser'] = util.randomize(
                 defaults.defaultFonts
@@ -85,21 +104,24 @@ export default {
      * Updates the current background to a new random one.
      */
     updateRandomBackground: function() {
-        let bodyPattern = trianglify({
-            width: window.innerWidth,
-            height: window.innerHeight,
-            cellSize: Math.random() * 200 + 40,
-            xColors: 'random',
-            variance: Math.random(),
-        }).toCanvas();
+        // Lazy load trianglify
+        getTrianglify().then((trianglify) => {
+            let bodyPattern = trianglify({
+                width: window.innerWidth,
+                height: window.innerHeight,
+                cellSize: Math.random() * 200 + 40,
+                xColors: 'random',
+                variance: Math.random(),
+            }).toCanvas();
 
-        jss.set('body', {
-            'background-image': `url(${bodyPattern.toDataURL('image/png').toString()})`,
-        });
+            jss.set('body', {
+                'background-image': `url(${bodyPattern.toDataURL('image/png').toString()})`,
+            });
 
-        jss.set('.modal-content', {
-            'background-image': `url(${bodyPattern.toDataURL('image/png').toString()})`,
-        });
+            jss.set('.modal-content', {
+                'background-image': `url(${bodyPattern.toDataURL('image/png').toString()})`,
+            });
+        }).catch((e) => { util.error('Could not load trianglify: ' + e); });
     },
 
     /**
@@ -130,111 +152,121 @@ export default {
                 // return;
             }
 
-            let xColors = [theme.themeContent.backgroundColor];
+            // Lazy compute colors and trianglify background
+            getTinycolor().then((tinycolor) => {
+                let xColors = [theme.themeContent.backgroundColor];
 
-            // Convert variance from my option to actual values.
-            let triVariance = 0.75;
-            switch (
-                theme.themeContent['trivariance-chooser'].toLowerCase()
-            ) {
-            case 'uniform':
-                triVariance = 0;
-                break;
+                // Convert variance from my option to actual values.
+                let triVariance = 0.75;
+                switch (
+                    theme.themeContent['trivariance-chooser'].toLowerCase()
+                ) {
+                case 'uniform':
+                    triVariance = 0;
+                    break;
 
-            case 'bent':
-                triVariance = 0.375;
-                break;
+                case 'bent':
+                    triVariance = 0.375;
+                    break;
 
-            case 'freeform':
-                triVariance = 0.75;
-                break;
+                case 'freeform':
+                    triVariance = 0.75;
+                    break;
 
-            default:
-                util.error(
-                    `Could not recognize trivariance: ${theme.themeContent['trivariance-chooser']}`
-                );
-                break;
-            }
+                default:
+                    util.error(
+                        `Could not recognize trivariance: ${theme.themeContent['trivariance-chooser']}`
+                    );
+                    break;
+                }
 
-            let triSize = 70;
-            switch (theme.themeContent['trisize-chooser'].toLowerCase()) {
-            case 'small':
-                triSize = 25;
-                break;
+                let triSize = 70;
+                switch (theme.themeContent['trisize-chooser'].toLowerCase()) {
+                case 'small':
+                    triSize = 25;
+                    break;
 
-            case 'medium':
-                triSize = 70;
-                break;
+                case 'medium':
+                    triSize = 70;
+                    break;
 
-            case 'large':
-                triSize = 125;
-                break;
+                case 'large':
+                    triSize = 125;
+                    break;
 
-            case 'yuge':
-                triSize = 240;
-                break;
+                case 'yuge':
+                    triSize = 240;
+                    break;
 
-            default:
-                util.error(
-                    `Could not recognize trisize: ${theme.themeContent['trisize-chooser']}`
-                );
-                break;
-            }
+                default:
+                    util.error(
+                        `Could not recognize trisize: ${theme.themeContent['trisize-chooser']}`
+                    );
+                    break;
+                }
 
-            switch (theme.themeContent['tristyle-chooser'].toLowerCase()) {
-            case 'triad':
-                xColors = tinycolor(theme.themeContent.backgroundColor)
-                    .triad()
-                    .map((v) => v.toHexString());
-                break;
-            case 'tetrad':
-                xColors = tinycolor(theme.themeContent.backgroundColor)
-                    .tetrad()
-                    .map((v) => v.toHexString());
-                break;
-            case 'monochromatic':
-                xColors = tinycolor(theme.themeContent.backgroundColor)
-                    .monochromatic()
-                    .map((v) => v.toHexString());
-                break;
-            case 'split complements':
-                xColors = tinycolor(theme.themeContent.backgroundColor)
-                    .splitcomplement()
-                    .map((v) => v.toHexString());
-                break;
-            default:
-                util.error(
-                    `Could not recognize tristyle: ${theme.themeContent['tristyle-chooser']}`
-                );
-                break;
-            }
+                switch (theme.themeContent['tristyle-chooser'].toLowerCase()) {
+                case 'triad':
+                    xColors = tinycolor(theme.themeContent.backgroundColor)
+                        .triad()
+                        .map((v) => v.toHexString());
+                    break;
+                case 'tetrad':
+                    xColors = tinycolor(theme.themeContent.backgroundColor)
+                        .tetrad()
+                        .map((v) => v.toHexString());
+                    break;
+                case 'monochromatic':
+                    xColors = tinycolor(theme.themeContent.backgroundColor)
+                        .monochromatic()
+                        .map((v) => v.toHexString());
+                    break;
+                case 'split complements':
+                    xColors = tinycolor(theme.themeContent.backgroundColor)
+                        .splitcomplement()
+                        .map((v) => v.toHexString());
+                    break;
+                default:
+                    util.error(
+                        `Could not recognize tristyle: ${theme.themeContent['tristyle-chooser']}`
+                    );
+                    break;
+                }
 
-            let bodyPattern = trianglify({
-                width: jBody.prop('scrollWidth'),
-                height: jBody.prop('scrollHeight'),
-                variance: triVariance,
-                cellSize: triSize,
-                xColors: xColors,
-                seed: 'metro-start',
-            }).toCanvas();
-            jss.set('.background-color', {
-                'background-color': theme.themeContent.backgroundColor,
-            });
-            jss.set('body', {
-                'background-image': `url(${bodyPattern.toDataURL('image/png').toString()})`,
-            });
+                // Now load trianglify and render
+                getTrianglify().then((trianglify) => {
+                    try {
+                        let bodyPattern = trianglify({
+                            width: jBody.prop('scrollWidth'),
+                            height: jBody.prop('scrollHeight'),
+                            variance: triVariance,
+                            cellSize: triSize,
+                            xColors: xColors,
+                            seed: 'metro-start',
+                        }).toCanvas();
+                        jss.set('.background-color', {
+                            'background-color': theme.themeContent.backgroundColor,
+                        });
+                        jss.set('body', {
+                            'background-image': `url(${bodyPattern.toDataURL('image/png').toString()})`,
+                        });
 
-            let modalPattern = trianglify({
-                width: jBody.prop('scrollWidth') * 0.75,
-                height: jBody.prop('scrollHeight') * 0.85,
-                variance: triVariance,
-                cellSize: triSize,
-                xColors: xColors,
-            }).toCanvas();
+                        let modalPattern = trianglify({
+                            width: jBody.prop('scrollWidth') * 0.75,
+                            height: jBody.prop('scrollHeight') * 0.85,
+                            variance: triVariance,
+                            cellSize: triSize,
+                            xColors: xColors,
+                        }).toCanvas();
 
-            jss.set('.modal-content', {
-                'background-image': `url(${modalPattern.toDataURL('image/png').toString()})`,
-            });
+                        jss.set('.modal-content', {
+                            'background-image': `url(${modalPattern.toDataURL('image/png').toString()})`,
+                        });
+                    } catch (e) {
+                        util.error('Failed to render trianglify background: ' + e);
+                    }
+                }).catch((e) => { util.error('Could not load trianglify: ' + e); });
+            }).catch((e) => { util.error('Could not load tinycolor: ' + e); });
         } else {
             jquery('.background-color').animate({
                 backgroundColor: theme.themeContent.backgroundColor,

--- a/es6/utils/script.js
+++ b/es6/utils/script.js
@@ -476,9 +476,25 @@ export default {
     },
 
     getShadow: function(data, color) {
-        let shadow = tinycolor(color);
-        return data.themeContent['fontreadability-chooser'] === 'on' ? `${shadow.spin(90)} 0 0 0.1em, ${shadow.spin(180)} 0 0 0.2em` : 'none';
+        // Avoid importing tinycolor synchronously here. If tinycolor has been
+        // lazy-loaded already, use it; otherwise return a simple fallback so
+        // the UI doesn't force tinycolor into the main bundle.
+        if (!color) return 'none';
+        try {
+            if (_tinycolor) {
+                const tc = _tinycolor(color);
+                return data.themeContent['fontreadability-chooser'] === 'on'
+                    ? `${tc.spin(90)} 0 0 0.1em, ${tc.spin(180)} 0 0 0.2em`
+                    : 'none';
+            }
+        } catch (e) {
+            // fallthrough to fallback
+        }
+        return data.themeContent['fontreadability-chooser'] === 'on'
+            ? `${color} 0 0 0.1em, ${color} 0 0 0.2em`
+            : 'none';
     },
+
 
     jssSetMultiple: function(selectors, style) {
         console.log(selectors, style);

--- a/es6/widgets/themes.js
+++ b/es6/widgets/themes.js
@@ -18,6 +18,12 @@ const getTinycolor = async () => {
 let _spectrumLoaded = false;
 const ensureSpectrum = async () => {
     if (!_spectrumLoaded) {
+        // Load CSS then JS for spectrum so styles are not pulled into the main bundle.
+        try {
+            await import('spectrum-colorpicker/spectrum.css');
+        } catch (e) {
+            // importing CSS might be a no-op in some bundler configs; ignore failures.
+        }
         await import('spectrum-colorpicker');
         _spectrumLoaded = true;
     }

--- a/es6/widgets/themes.js
+++ b/es6/widgets/themes.js
@@ -1,5 +1,4 @@
 import jquery from 'jquery';
-import tinycolor from 'tinycolor2';
 import {throttle} from 'throttle-debounce';
 import modal from '../utils/modal';
 import util from '../utils/util';
@@ -7,7 +6,22 @@ import storage from '../utils/storage';
 import defaults from '../utils/defaults';
 import script from '../utils/script';
 import 'metro-select';
-import 'spectrum-colorpicker';
+// Lazy-load spectrum and tinycolor where needed to reduce initial bundle size
+let _tinycolor = null;
+const getTinycolor = async () => {
+    if (!_tinycolor) {
+        const mod = await import('tinycolor2');
+        _tinycolor = mod.default || mod;
+    }
+    return _tinycolor;
+};
+let _spectrumLoaded = false;
+const ensureSpectrum = async () => {
+    if (!_spectrumLoaded) {
+        await import('spectrum-colorpicker');
+        _spectrumLoaded = true;
+    }
+};
 
 export default {
     isBound: false,
@@ -246,19 +260,23 @@ export default {
      * @param {any} inputElement The name of the field to turn into a spectrum.
      */
     bindColorInput: function(inputElement) {
-        jquery(inputElement).spectrum({
-            chooseText: 'save color',
-            replacerClassName: 'spectrum-replacer',
-            appendTo: inputElement.parentNode,
-            showButtons: false,
-            color: this.data.themeContent[inputElement.id],
-            move: throttle(
-                125,
-                this.updateColor.bind(this, inputElement.id),
-                true
-            ),
-        });
+        // Ensure spectrum plugin is loaded before initializing
+        ensureSpectrum().then(() => {
+            jquery(inputElement).spectrum({
+                chooseText: 'save color',
+                replacerClassName: 'spectrum-replacer',
+                appendTo: inputElement.parentNode,
+                showButtons: false,
+                color: this.data.themeContent[inputElement.id],
+                move: throttle(
+                    125,
+                    this.updateColor.bind(this, inputElement.id),
+                    true
+                ),
+            });
+        }).catch((e) => { util.error('Failed to load spectrum: ' + e); });
     },
+
 
     /**
      * Handles changes to metro-select elements.
@@ -411,19 +429,61 @@ export default {
     },
 
     autoPaletteAdjust: function() {
-        let baseColor = tinycolor(this.data.themeContent.baseColor);
-        this.data.themeContent.backgroundColor = baseColor.toHexString();
-        this.data.themeContent.titleColor = this.getReadable(
-            tinycolor(this.data.themeContent.baseColor), -1.6
-        );
-        this.data.themeContent.mainColor = this.getReadable(
-            tinycolor(this.data.themeContent.baseColor),
-            1.8
-        );
-        this.data.themeContent.optionsColor = this.getReadable(
-            tinycolor(this.data.themeContent.baseColor),
-            1.25
-        );
+        // Lazy-load tinycolor and compute palette asynchronously
+        getTinycolor().then((tinycolor) => {
+            try {
+                const baseColor = tinycolor(this.data.themeContent.baseColor);
+                this.data.themeContent.backgroundColor = baseColor.toHexString();
+
+                const computeReadable = (color, multiplier) => {
+                    return tinycolor
+                        .mostReadable(
+                            color,
+                            [
+                                tinycolor(color.toHexString()).spin(multiplier * 38),
+                                tinycolor(color.toHexString()).spin(multiplier * 100),
+                                tinycolor(color.toHexString()).spin(multiplier * 190),
+                                tinycolor(color.toHexString()).spin(multiplier * 242),
+                                tinycolor(color.toHexString()).spin(multiplier * 303),
+                                tinycolor(color.toHexString()).spin(multiplier * 38).darken(25),
+                                tinycolor(color.toHexString()).spin(multiplier * 100).darken(25),
+                                tinycolor(color.toHexString()).spin(multiplier * 190).darken(25),
+                                tinycolor(color.toHexString()).spin(multiplier * 242).darken(25),
+                                tinycolor(color.toHexString()).spin(multiplier * 303).darken(25),
+                                tinycolor(color.toHexString()).spin(multiplier * 38).brighten(25),
+                                tinycolor(color.toHexString()).spin(multiplier * 100).brighten(25),
+                                tinycolor(color.toHexString()).spin(multiplier * 190).brighten(25),
+                                tinycolor(color.toHexString()).spin(multiplier * 242).brighten(25),
+                                tinycolor(color.toHexString()).spin(multiplier * 303).brighten(25),
+                            ],
+                            { includeFallbackColors: false }
+                        )
+                        .toHexString();
+                };
+
+                this.data.themeContent.titleColor = computeReadable(
+                    tinycolor(this.data.themeContent.baseColor),
+                    -1.6
+                );
+                this.data.themeContent.mainColor = computeReadable(
+                    tinycolor(this.data.themeContent.baseColor),
+                    1.8
+                );
+                this.data.themeContent.optionsColor = computeReadable(
+                    tinycolor(this.data.themeContent.baseColor),
+                    1.25
+                );
+
+                // Apply updated theme
+                const updatedTheme = script.updateTheme(this.data, this.oldTheme, true);
+                this.oldTheme = updatedTheme;
+                storage.save('currentTheme', updatedTheme);
+            } catch (e) {
+                util.error('Failed to compute auto palette: ' + e);
+            }
+        }).catch((e) => {
+            util.error('Could not load tinycolor for auto palette: ' + e);
+        });
     },
 
     /**
@@ -433,50 +493,4 @@ export default {
      * @param {any} multiplier A value to scale the spin by to add some variance.
      * @return {any} The most readable color.
      */
-    getReadable: function(color, multiplier) {
-        return tinycolor
-            .mostReadable(
-                color, [
-                    // My reckons for good color stops :shrug:
-                    tinycolor(color.toHexString()).spin(multiplier * 38),
-                    tinycolor(color.toHexString()).spin(multiplier * 100),
-                    tinycolor(color.toHexString()).spin(multiplier * 190),
-                    tinycolor(color.toHexString()).spin(multiplier * 242),
-                    tinycolor(color.toHexString()).spin(multiplier * 303),
-                    tinycolor(color.toHexString())
-                        .spin(multiplier * 38)
-                        .darken(25),
-                    tinycolor(color.toHexString())
-                        .spin(multiplier * 100)
-                        .darken(25),
-                    tinycolor(color.toHexString())
-                        .spin(multiplier * 190)
-                        .darken(25),
-                    tinycolor(color.toHexString())
-                        .spin(multiplier * 242)
-                        .darken(25),
-                    tinycolor(color.toHexString())
-                        .spin(multiplier * 303)
-                        .darken(25),
-                    tinycolor(color.toHexString())
-                        .spin(multiplier * 38)
-                        .brighten(25),
-                    tinycolor(color.toHexString())
-                        .spin(multiplier * 100)
-                        .brighten(25),
-                    tinycolor(color.toHexString())
-                        .spin(multiplier * 190)
-                        .brighten(25),
-                    tinycolor(color.toHexString())
-                        .spin(multiplier * 242)
-                        .brighten(25),
-                    tinycolor(color.toHexString())
-                        .spin(multiplier * 303)
-                        .brighten(25),
-                ], {
-                    includeFallbackColors: false,
-                }
-            )
-            .toHexString();
-    },
 };

--- a/es6/widgets/themes.js
+++ b/es6/widgets/themes.js
@@ -30,6 +30,7 @@ const ensureSpectrum = async () => {
 };
 
 export default {
+    name: 'themes',
     isBound: false,
 
     sessionUpdateCount: 0,

--- a/es6/widgets/widgets.js
+++ b/es6/widgets/widgets.js
@@ -1,16 +1,40 @@
 import weather from './weather';
-import themes from './themes';
 import about from './about';
+
+let _themesModule = null;
+
 export default {
     weather: weather,
-    themes: themes,
     about: about,
 
-    data: [weather, themes, about],
+    data: [weather, about],
 
     init: function(document) {
+        // Initialize light-weight or always-used widgets immediately.
         this.data.forEach((module) => {
             module.init(document);
         });
+
+        // Defer loading the themes module until the user attempts to open it.
+        const editBtn = document.getElementById('editThemeButton');
+        if (editBtn) {
+            const handler = async (e) => {
+                editBtn.removeEventListener('click', handler);
+                try {
+                    if (!_themesModule) {
+                        const mod = await import('./themes');
+                        _themesModule = mod.default || mod;
+                        _themesModule.init(document);
+                    }
+                    // After init, open the editor immediately.
+                    if (_themesModule && _themesModule.openThemeEditor) {
+                        _themesModule.openThemeEditor();
+                    }
+                } catch (err) {
+                    console.error('Failed to load themes module:', err);
+                }
+            };
+            editBtn.addEventListener('click', handler);
+        }
     },
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "build": "npx webpack",
+    "build": "npx webpack --env target=chrome",
     "build:demo": "npm run build && node scripts/generate-demo.js"
   },
   "repository": {

--- a/scripts/generate-demo.js
+++ b/scripts/generate-demo.js
@@ -66,9 +66,16 @@ const sampleJs = Object.keys(sampleData).map(k => {
 fs.writeFileSync(path.join(demoDir, 'sample-data.js'), sampleJs, 'utf8');
 console.log('Wrote demo/sample-data.js');
 
-// Copy the built bundle to demo/dist
-fs.copyFileSync(distSrc, path.join(demoDist, 'metro-start.js'));
-console.log('Copied bundle to demo/dist/metro-start.js');
+// Copy all generated JS/CSS assets from dist/chrome into demo/dist
+const distDir = path.join(repoRoot, 'dist', 'chrome');
+const assets = fs.readdirSync(distDir);
+assets.forEach(f => {
+    const ext = path.extname(f).toLowerCase();
+    if (['.js', '.css', '.map'].includes(ext) || f === 'metro-start.js') {
+        fs.copyFileSync(path.join(distDir, f), path.join(demoDist, f));
+        console.log('Copied', f, 'to demo/dist');
+    }
+});
 
 // Read start.html and modify it for demo usage: insert sample-data.js and point script to dist/metro-start.js
 let html = fs.readFileSync(htmlPath, 'utf8');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,8 +45,20 @@ const config = {
 var chromeConfig = Object.assign({}, config, {
     output: {
         filename: 'metro-start.js',
+        chunkFilename: 'chrome.[name].[contenthash].js',
         path: `${__dirname}/dist/chrome`,
     },
+    optimization: Object.assign({}, config.optimization, {
+        splitChunks: {
+            chunks: 'all',
+            maxInitialRequests: 25,
+            minSize: 20000,
+        },
+        // keep runtime separate so vendor splitting is effective
+        runtimeChunk: 'single',
+        // minify the chrome demo build to reduce bundle size
+        minimize: true,
+    }),
     plugins: [
         new CopyPlugin({
             patterns: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,12 +9,6 @@ const baseConfig = {
     mode: 'production',
     optimization: {
         minimize: false,
-        splitChunks: {
-            chunks: 'all',
-            maxInitialRequests: 25,
-            minSize: 20000,
-        },
-        runtimeChunk: 'single',
     },
     stats: {
         colors: true,
@@ -73,7 +67,16 @@ const createCopyPatterns = (manifestTransform) => [
 const chromeConfig = createConfig('chrome', {
     output: {
         filename: 'metro-start.js',
+        chunkFilename: '[name].[contenthash].js',
         path: `${__dirname}/dist/chrome`,
+    },
+    optimization: {
+        splitChunks: {
+            chunks: 'all',
+            maxInitialRequests: 25,
+            minSize: 20000,
+        },
+        runtimeChunk: 'single',
     },
     plugins: [
         new CopyPlugin({patterns: createCopyPatterns()}),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,15 +48,11 @@ var chromeConfig = Object.assign({}, config, {
         chunkFilename: 'chrome.[name].[contenthash].js',
         path: `${__dirname}/dist/chrome`,
     },
-    optimization: Object.assign({}, config.optimization, {
-        splitChunks: {
-            chunks: 'all',
-            maxInitialRequests: 25,
-            minSize: 20000,
-        },
-        // minify the chrome demo build to reduce bundle size
-        minimize: true,
-    }),
+    // For the demo build we suppress performance hints rather than forcing
+    // aggressive code-splitting here to avoid multi-compiler chunk filename issues.
+    performance: {
+        hints: false,
+    },
     plugins: [
         new CopyPlugin({
             patterns: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -127,4 +127,19 @@ const xcodeConfig = createConfig('xcode', {
     ],
 });
 
-module.exports = [chromeConfig, firefoxConfig, xcodeConfig];
+module.exports = (env = {}) => {
+    // Allow selecting a specific target via --env target=chrome|firefox|xcode|all
+    const target = env.target || process.env.BUILD_TARGET || 'chrome';
+    switch (target) {
+        case 'chrome':
+            return chromeConfig;
+        case 'firefox':
+            return firefoxConfig;
+        case 'xcode':
+            return xcodeConfig;
+        case 'all':
+            return [chromeConfig, firefoxConfig, xcodeConfig];
+        default:
+            return chromeConfig;
+    }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,15 +44,14 @@ const config = {
 
 var chromeConfig = Object.assign({}, config, {
     output: {
+        // Main entry remains metro-start.js (single-file for extension packaging).
         filename: 'metro-start.js',
-        chunkFilename: 'chrome.[name].[contenthash].js',
+        // Lazy-loaded chunks use a predictable pattern so they can be included in the extension
+        // package directory alongside metro-start.js when needed.
+        chunkFilename: '[name].[contenthash].js',
         path: `${__dirname}/dist/chrome`,
     },
-    // For the demo build we suppress performance hints rather than forcing
-    // aggressive code-splitting here to avoid multi-compiler chunk filename issues.
-    performance: {
-        hints: false,
-    },
+    // Keep default optimization (no splitChunks/runtimeChunk) so vendors/runtime stay in the main bundle.
     plugins: [
         new CopyPlugin({
             patterns: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -134,4 +134,19 @@ var xcodeConfig = Object.assign({}, config, {
         filename: 'metro-start-xcode.zip',
     })]});
     
-module.exports = [chromeConfig, firefoxConfig, xcodeConfig];
+module.exports = (env = {}) => {
+    // Allow selecting a specific target via --env target=chrome|firefox|xcode|all
+    const target = env.target || process.env.BUILD_TARGET || 'chrome';
+    switch (target) {
+        case 'chrome':
+            return chromeConfig;
+        case 'firefox':
+            return firefoxConfig;
+        case 'xcode':
+            return xcodeConfig;
+        case 'all':
+            return [chromeConfig, firefoxConfig, xcodeConfig];
+        default:
+            return chromeConfig;
+    }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,8 +54,6 @@ var chromeConfig = Object.assign({}, config, {
             maxInitialRequests: 25,
             minSize: 20000,
         },
-        // keep runtime separate so vendor splitting is effective
-        runtimeChunk: 'single',
         // minify the chrome demo build to reduce bundle size
         minimize: true,
     }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,9 @@
 const path = require('path');
-const {version} = require('./package.json');
+const packageJson = require('./package.json');
 const CopyPlugin = require('copy-webpack-plugin');
 const ZipPlugin = require('zip-webpack-plugin');
 
-const baseConfig = {
+const config = {
     entry: './es6/app.js',
     devtool: 'inline-source-map',
     mode: 'production',
@@ -27,7 +27,7 @@ const baseConfig = {
                 test: /\.css$/i,
                 use: [
                     'style-loader',
-                    'css-loader',
+                    'css-loader'
                 ],
             },
             {
@@ -39,107 +39,87 @@ const baseConfig = {
                 ],
             },
         ],
-    },
+    }
 };
 
-const createConfig = (name, overrides = {}) => ({
-    ...baseConfig,
-    ...overrides,
-});
-
-const createCopyPatterns = (manifestTransform) => [
-    {from: 'html/start.html'},
-    {from: 'icons/*'},
-    {
-        from: 'manifest.template.json',
-        to: 'manifest.json',
-        transform: (content) => {
-            const manifest = JSON.parse(content.toString());
-            manifest.version = version;
-            if (manifestTransform) {
-                manifestTransform(manifest);
-            }
-            return JSON.stringify(manifest);
-        },
-    },
-];
-
-const chromeConfig = createConfig('chrome', {
+var chromeConfig = Object.assign({}, config, {
     output: {
         filename: 'metro-start.js',
-        chunkFilename: '[name].[contenthash].js',
         path: `${__dirname}/dist/chrome`,
     },
-    optimization: {
-        splitChunks: {
-            chunks: 'all',
-            maxInitialRequests: 25,
-            minSize: 20000,
-        },
-        runtimeChunk: 'single',
-    },
     plugins: [
-        new CopyPlugin({patterns: createCopyPatterns()}),
+        new CopyPlugin({
+            patterns: [
+                {from: 'html/start.html'},
+                {from: 'icons/*' },
+                {
+                    from: 'manifest.template.json',
+                    to: 'manifest.json',
+                    transform(content) {
+                        let manifest = JSON.parse(content.toString());
+                        manifest.version = packageJson.version;
+                        return JSON.stringify(manifest);
+                    }
+                }]}),
         new ZipPlugin({
             path: `${__dirname}/dist`,
             filename: 'metro-start-chrome.zip',
-        }),
-    ],
+        })]
 });
 
-const firefoxConfig = createConfig('firefox', {
+var firefoxConfig = Object.assign({}, config, {
     output: {
         filename: 'metro-start.js',
         path: `${__dirname}/dist/firefox`,
     },
-    plugins: [
-        new CopyPlugin({
-            patterns: createCopyPatterns((manifest) => {
-                manifest.manifest_version = 2;
-                manifest.permissions.push(...(manifest.host_permissions || []));
-                delete manifest.host_permissions;
-                manifest.browser_specific_settings = {
-                    gecko: {
-                        id: 'metro-start@metro-start.com',
-                        strict_min_version: '77.0',
-                    },
-                };
-            }),
-        }),
-        new ZipPlugin({
-            path: `${__dirname}/dist`,
-            filename: 'metro-start-firefox.zip',
-        }),
-    ],
-});
+    plugins: [new CopyPlugin({
+        patterns: [
+            {from: 'html/start.html'},
+            {from: 'icons/*' },
+            {
+                from: 'manifest.template.json',
+                to: 'manifest.json',
+                transform(content) {
+                    let manifest = JSON.parse(content.toString());
+                    manifest.version = packageJson.version;
+                    manifest.manifest_version = 2;
+                    manifest.browser_specific_settings = {
+                        gecko: {
+                            id: 'metro-start@metro-start.com',
+                            strict_min_version: '77.0'
+                        }
+                    };
+                    return JSON.stringify(manifest);
+                }
+            }]
+    }),
+    new ZipPlugin({
+        path: `${__dirname}/dist`,
+        filename: 'metro-start-firefox.zip',
+    })]});
 
-const xcodeConfig = createConfig('xcode', {
+var xcodeConfig = Object.assign({}, config, {
     output: {
         filename: 'metro-start.js',
         path: `${__dirname}/dist/xcode`,
     },
-    plugins: [
-        new CopyPlugin({patterns: createCopyPatterns()}),
-        new ZipPlugin({
-            path: `${__dirname}/dist`,
-            filename: 'metro-start-xcode.zip',
-        }),
-    ],
-});
-
-module.exports = (env = {}) => {
-    // Allow selecting a specific target via --env target=chrome|firefox|xcode|all
-    const target = env.target || process.env.BUILD_TARGET || 'chrome';
-    switch (target) {
-        case 'chrome':
-            return chromeConfig;
-        case 'firefox':
-            return firefoxConfig;
-        case 'xcode':
-            return xcodeConfig;
-        case 'all':
-            return [chromeConfig, firefoxConfig, xcodeConfig];
-        default:
-            return chromeConfig;
-    }
-};
+    plugins: [new CopyPlugin({
+        patterns: [
+            {from: 'html/start.html'},
+            {from: 'icons/*' },
+            {
+                from: 'manifest.template.json',
+                to: 'manifest.json',
+                transform(content) {
+                    let manifest = JSON.parse(content.toString());
+                    manifest.version = packageJson.version;
+                    return JSON.stringify(manifest);
+                }
+            }]
+    }),
+    new ZipPlugin({
+        path: `${__dirname}/dist`,
+        filename: 'metro-start-xcode.zip',
+    })]});
+    
+module.exports = [chromeConfig, firefoxConfig, xcodeConfig];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,12 @@ const baseConfig = {
     mode: 'production',
     optimization: {
         minimize: false,
+        splitChunks: {
+            chunks: 'all',
+            maxInitialRequests: 25,
+            minSize: 20000,
+        },
+        runtimeChunk: 'single',
     },
     stats: {
         colors: true,


### PR DESCRIPTION
Why

This change makes the project runnable as a simple browser demo without installing it as an extension. It helps with easier local testing and demoing while also upgrading several dependencies and hardening extension API usage for non-extension contexts.

What

- Add demo build and generator (scripts/generate-demo.js) that copies bundles and writes demo/sample-data.js for localStorage-backed sample data.
- Add runtime shims in es6/utils/extension.js to fallback to localStorage and safe no-op permissions when browser/ chrome extension APIs are unavailable.
- Update widgets (weather, themes) and utils (script) to handle demo/file:// mode and to lazy-load heavy libraries (tinycolor, trianglify, spectrum) to reduce initial bundle size.
- Upgrade dev dependencies and modernize build (webpack), ESLint rules, and various small refactors.
- Fix runtime errors: guard against browser.storage.sync and browser.permissions.getAll to prevent "undefined is not an object" in non-extension contexts.

Notes and remaining items

- Build succeeds; webpack emits size warnings (metro-start.js ~1.3 MiB). Further code-splitting or removing heavy libs will reduce this.
- Trianglify / node-canvas brings an upstream native dependency and a tar vulnerability via node-pre-gyp; consider replacing trianglify or pinning when upstream fixes are available.
- Demo runs under file:// using localStorage sample data. Optionally serving demo from a static server is recommended for more realistic network behavior.

Reviewers

Please review the extension API shim (es6/utils/extension.js), the demo generator (scripts/generate-demo.js), and the lazy-loading changes in es6/utils/script.js and es6/widgets/themes.js. If you'd like, I can follow up by converting remaining synchronous tinycolor/trianglify uses and further reduce bundle size.